### PR TITLE
Don't run (failure-count) on empty list

### DIFF
--- a/bin/exercise.ss
+++ b/bin/exercise.ss
@@ -9,18 +9,19 @@
                     (tests . ,tests)
                     (output . ,output))))))
 
-(define (report-results chez guile)
-  (if (zero? (+ (length chez) (length guile)))
-    (output-results "fail" '() "Syntax error")
-    (let ((choice (cond
-                    ((null? guile) chez)
-                    ((null? chez) guile)
-                    (else (if (<= (failure-count chez) (failure-count guile))
-                            chez
-                            guile)))))
-      (if (zero? (failure-count choice))
-          (output-results "pass" (failure-messages choice) "")
-          (output-results "fail" (failure-messages choice) "")))))
+(define report-results
+  (let ((pass-or-fail
+         (lambda (result)
+           (output-results
+            (or (and (zero? (failure-count result)) "pass") "fail")
+            (failure-messages result) ""))))
+    (lambda (chez guile)
+      (cond
+       ((andmap null? `(,chez ,guile))
+        (output-results "fail" '() "Syntax error"))
+       (else
+        (if (not (null? chez)) (pass-or-fail chez)
+            (pass-or-fail guile)))))))
 
 ;; read s-expression from process stdout
 (define (process->scheme command)

--- a/bin/exercise.ss
+++ b/bin/exercise.ss
@@ -10,15 +10,17 @@
                     (output . ,output))))))
 
 (define (report-results chez guile)
-  (case (+ (length chez) (length guile))
-    (0 (output-results "fail" '() "Syntax error"))
-    (else 
-      (let ((choice (if (<= (failure-count chez) (failure-count guile))
-                      chez
-                      guile)))
+  (if (zero? (+ (length chez) (length guile)))
+    (output-results "fail" '() "Syntax error")
+    (let ((choice (cond
+                    ((null? guile) chez)
+                    ((null? chez) guile)
+                    (else (if (<= (failure-count chez) (failure-count guile))
+                            chez
+                            guile)))))
       (if (zero? (failure-count choice))
           (output-results "pass" (failure-messages choice) "")
-          (output-results "fail" (failure-messages choice) ""))))))
+          (output-results "fail" (failure-messages choice) "")))))
 
 ;; read s-expression from process stdout
 (define (process->scheme command)


### PR DESCRIPTION
If Chez or Guile crash or return no output to stdout then the result from convert
will be null which gets passed to failure-count. failure-count then
calls car on null thus crashing the test runner.

This patch prevents calling failure-count when either chez-result or
guile-result is null.

This fixes #23.