### PR TITLE
Debug

### DIFF
--- a/code/exercise.ss
+++ b/code/exercise.ss
@@ -17,7 +17,11 @@
     (lambda (chez guile)
       (cond
        ((andmap null? `(,chez ,guile))
-        (output-results "fail" '() "Syntax error"))
+        (write-results
+         `((version . 2)
+           (status . error)
+           (message . "legacy test crash")
+           (tests))))
        (else
         (if (not (null? chez)) (pass-or-fail chez)
             (pass-or-fail guile)))))))


### PR DESCRIPTION
This gives us better debug info on stderr when encountering the `Syntax error` result from the test-runner.  This gives us the full raw text output from both guile and chez in case we pass the syntax error failure on to the website.  This will help us debug with fuller information what is happening in the production containers running the tests for students.