### PR TITLE
Switch test runner to Guile 3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM ubuntu
 
 RUN apt-get update && \
-    apt-get install -y chezscheme-dev guile-2.2-dev gcc && \
+    apt-get install -y chezscheme-dev guile-3.0-dev gcc && \
     apt-get purge --auto-remove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 ENV C_INCLUDE_PATH=/usr/lib/csv9.5.4/ta6le:$C_INCLUDE_PATH
-ENV C_INCLUDE_PATH=/usr/lib/guile/2.2:$C_INCLUDE_PATH
+ENV C_INCLUDE_PATH=/usr/lib/guile/3.0:$C_INCLUDE_PATH
 
 WORKDIR /opt/test-runner
 COPY . .

--- a/tests/building-and-linking-c-guile/knapsack.scm
+++ b/tests/building-and-linking-c-guile/knapsack.scm
@@ -1,7 +1,7 @@
 (import (rnrs))
 
 ;; Build and load shared object library for matrix computations.
-(unless (and (zero? (system "C_INCLUDE_PATH=/usr/include/guile/2.2:\"$C_INCLUDE_PATH\" gcc -shared -o ksdp.so -Wall -Werror -fpic ksdp.c")))
+(unless (and (zero? (system "C_INCLUDE_PATH=/usr/include/guile/3.0:\"$C_INCLUDE_PATH\" gcc -shared -o ksdp.so -Wall -Werror -fpic ksdp.c")))
   (error 'knapsack.scm "gcc error building C auxillary library"))
 
 (dynamic-call "init_knapsack_solve" (dynamic-link "./ksdp.so"))

--- a/tests/building-and-linking-c-guile/ksdp.c
+++ b/tests/building-and-linking-c-guile/ksdp.c
@@ -1,4 +1,4 @@
-/* -*- flycheck-gcc-include-path: ("/usr/include/guile/2.2"); flycheck-clang-include-path: ("/usr/include/guile/2.2"); -*- */
+/* -*- flycheck-gcc-include-path: ("/usr/include/guile/3.0"); flycheck-clang-include-path: ("/usr/include/guile/3.0"); -*- */
 /* Shared object module for solving 0/1knapsack with dynamic programming */
 
 #include <stddef.h>


### PR DESCRIPTION
Guile 2.2 hasn't had a release since 2020. Ubuntu 22.04 currently ships with 3.0.7 for the guile-3.0 package.