### PR TITLE
Pin the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:26.04@sha256:f3d28607ddd78734bb7f71f117f3c6706c666b8b76cbff7c9ff6e5718d46ff64
 
 RUN apt-get update && \
     apt-get install -y chezscheme-dev guile-3.0-dev gcc && \

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-C_INCLUDE_PATH="/usr/lib/csv9.5.8/ta6le:/usr/include/guile/3.0"
+C_INCLUDE_PATH="/usr/lib/csv10.0.0/ta6le:/usr/include/guile/3.0"
 export C_INCLUDE_PATH
 


### PR DESCRIPTION
Exercism's policy is to prefer pinned versions.
Using the same hash across all runners allows us to store and reuse the same image, rather than needing to store a per-runner base image. This helps cut down on storage costs.
